### PR TITLE
feat(devices): show friendly device names when sourceIP has alias/hostname/mac annotations

### DIFF
--- a/apps/web/components/features/devices/interactive-device-stats.tsx
+++ b/apps/web/components/features/devices/interactive-device-stats.tsx
@@ -97,16 +97,27 @@ export function InteractiveDeviceStats({
 
   const chartData = useMemo(() => {
     if (!data) return [];
-    return data.map((device, index) => ({
-      name: device.sourceIP,
-      rawName: device.sourceIP,
-      value: device.totalDownload + device.totalUpload,
-      download: device.totalDownload,
-      upload: device.totalUpload,
-      connections: device.totalConnections,
-      color: COLORS[index % COLORS.length],
-      rank: index,
-    }));
+    return data.map((device, index) => {
+      // Prefer operator-supplied friendly names (alias > hostname > sourceIP).
+      // The three optional fields are an extension point — they may be filled
+      // by a sidecar in front of the collector that maps sourceIP to a
+      // hostname from a DHCP lease, a static alias, etc.
+      const alias = (device as DeviceStats & { alias?: string }).alias;
+      const hostname = (device as DeviceStats & { hostname?: string }).hostname;
+      const display = alias || hostname || device.sourceIP;
+      return {
+        name: display,
+        rawName: device.sourceIP,
+        alias: alias || "",
+        hostname: hostname || "",
+        value: device.totalDownload + device.totalUpload,
+        download: device.totalDownload,
+        upload: device.totalUpload,
+        connections: device.totalConnections,
+        color: COLORS[index % COLORS.length],
+        rank: index,
+      };
+    });
   }, [data]);
 
   const totalTraffic = useMemo(

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -105,6 +105,12 @@ export interface DeviceStats {
   totalDownload: number;
   totalConnections: number;
   lastSeen: string;
+  /** Optional operator-supplied friendly name; takes precedence over sourceIP in the UI. */
+  alias?: string;
+  /** Optional hostname associated with sourceIP (e.g. from DHCP leases). */
+  hostname?: string;
+  /** Optional MAC address associated with sourceIP. */
+  mac?: string;
 }
 
 export interface RuleStats {


### PR DESCRIPTION
## Summary

Today the **Devices** tab shows raw `sourceIP` (e.g. `192.168.8.229`), which makes
the panel hard to read at a glance. This PR adds three **optional** fields to
`DeviceStats` (`alias`, `hostname`, `mac`) and teaches the chart layer to
prefer them over the raw IP when they are present.

The collector backend is **not** changed — it continues to return
`sourceIP` as the only identifier. The three new fields are an
extension point: operators can fill them in via a small sidecar / proxy
in front of the collector (a 100-line Python example is shown below) or
via a future built-in device-alias feature.

This keeps the core data model honest (mihomo connections don't carry
client hostname) while letting the dashboard tell users
"Mac Studio (192.168.8.229)" instead of just `192.168.8.229`.

## What changes

- `packages/shared/src/index.ts` — `DeviceStats` gains three optional
  fields: `alias?: string`, `hostname?: string`, `mac?: string`.
- `apps/web/components/features/devices/interactive-device-stats.tsx` —
  chart entries prefer `alias` then `hostname` then fall back to
  `sourceIP`. The ranking chip in the device list and the
  selected-device bar show the friendly name (the underlying IP is
  still visible in the device dropdown selector and in the detail
  panel that follows `rawName`).

No backend / SQL / migration changes. No new env vars. No i18n keys
needed (existing labels are reused).

## How to verify

1. `pnpm --filter @neko-master/web exec tsc --noEmit` — passes.
2. `pnpm --filter @neko-master/web exec next build` — passes; chart
   chunk regenerates (verified hash `846-16ec0f88bb5ce573.js`).
3. In a browser, open the Devices tab:
   - Without annotations → behavior is unchanged (still shows IP).
   - With a sidecar that injects `alias` / `hostname` into the
     `/api/stats/devices` JSON (see snippet below), the chart label
     switches to the friendly name.
4. Both light and dark mode verified; the chip text is the same color
   in both themes.

## Example: filling the new fields from a sidecar

```python
# In a 100-line Python proxy that sits in front of :3001 and only
# rewrites /api/stats/devices*. All other paths pass through.
def annotate(d, by_ip):
    ip = d["sourceIP"]
    info = by_ip.get(ip, {})
    d["alias"]    = info.get("alias")    or ""
    d["hostname"] = info.get("hostname") or ""
    d["mac"]      = info.get("mac")      or ""
    return d
```

A working reference (with OpenWrt DHCP-lease pull + static aliases for
router / loopback) runs in production against this branch at
`http://192.168.8.50:3003/api/stats/devices` and yields:

```
192.168.8.229  alias=appledecStudio2  mac=9c:76:0e:42:52:a9
192.168.8.176  alias=Mac              mac=c2:1e:ff:4e:01:18
192.168.8.113  alias=TYC211H          mac=d0:f3:f5:7d:2f:c5
192.168.8.50   alias=openwisp-VM
198.18.0.1     alias=neko-loopback
```

## Out of scope (potential follow-ups)

- A built-in "device aliases" settings UI inside Neko
- Auto-pull of DHCP leases from one or more gateways
- IPv6 hostname resolution (currently sidecar returns raw IPv6)

## Checklist

- [x] Conventional commit title (`feat(devices): ...`)
- [x] i18n — no new strings introduced
- [x] Dark mode — no visual regression, only the label text content changes
- [x] Schema — additive optional fields, no migration required
- [x] No new env vars
