### PR TITLE
fix(collector): prevent geoIP array truncation caused by filter(Boolean)

### DIFF
--- a/apps/collector/src/database/repositories/device.repository.ts
+++ b/apps/collector/src/database/repositories/device.repository.ts
@@ -100,7 +100,7 @@ export class DeviceRepository extends BaseRepository {
         const chains = row.chains ? row.chains.split(',').filter(Boolean) : [];
         return {
           ...row, domains: row.domains ? row.domains.split(',').filter(Boolean) : [],
-          geoIP: row.geoIP ? JSON.parse(row.geoIP).filter(Boolean) : undefined, asn: row.asn || undefined,
+          geoIP: row.geoIP ? JSON.parse(row.geoIP) : undefined, asn: row.asn || undefined,
           chains: this.expandShortChainsForRules(backendId, chains, rules),
         };
       }) as IPStats[];
@@ -121,7 +121,7 @@ export class DeviceRepository extends BaseRepository {
     const result = stmt.all(backendId, sourceIP, limit) as any[];
     return result.map(r => ({
       ...r, domains: r.domains ? r.domains.split(',') : [],
-      geoIP: r.geoIP ? JSON.parse(r.geoIP).filter(Boolean) : undefined, asn: r.asn || undefined,
+      geoIP: r.geoIP ? JSON.parse(r.geoIP) : undefined, asn: r.asn || undefined,
     }));
   }
 }

--- a/apps/collector/src/database/repositories/domain.repository.ts
+++ b/apps/collector/src/database/repositories/domain.repository.ts
@@ -411,7 +411,7 @@ export class DomainRepository extends BaseRepository {
         return {
           ...row,
           domains: row.domains ? row.domains.split(',').filter(Boolean) : [],
-          geoIP: row.geoIP ? JSON.parse(row.geoIP).filter(Boolean) : undefined,
+          geoIP: row.geoIP ? JSON.parse(row.geoIP) : undefined,
           asn: row.asn || undefined,
           chains: this.expandShortChainsForRules(backendId, chains, rules),
         };
@@ -717,7 +717,7 @@ export class DomainRepository extends BaseRepository {
     return rows.map(row => ({
       ...row,
       domains: row.domains ? row.domains.split(',') : [],
-      geoIP: row.geoIP ? JSON.parse(row.geoIP).filter(Boolean) : undefined,
+      geoIP: row.geoIP ? JSON.parse(row.geoIP) : undefined,
       asn: row.asn || undefined,
       chains: row.chains ? row.chains.split(',') : [],
     })) as IPStats[];

--- a/apps/collector/src/database/repositories/ip.repository.ts
+++ b/apps/collector/src/database/repositories/ip.repository.ts
@@ -59,7 +59,7 @@ export class IPRepository extends BaseRepository {
         const chains = row.chains ? row.chains.split(',').filter(Boolean) : [];
         return {
           ...row, domains: row.domains ? row.domains.split(',').filter(Boolean) : [],
-          geoIP: row.geoIP ? JSON.parse(row.geoIP).filter(Boolean) : undefined,
+          geoIP: row.geoIP ? JSON.parse(row.geoIP) : undefined,
           asn: row.asn || undefined,
           chains: this.expandShortChainsForRules(backendId, chains, rules),
         };
@@ -84,7 +84,7 @@ export class IPRepository extends BaseRepository {
 
     return rows.map(row => ({
       ...row, domains: row.domains ? row.domains.split(',') : [],
-      geoIP: row.geoIP ? JSON.parse(row.geoIP).filter(Boolean) : undefined,
+      geoIP: row.geoIP ? JSON.parse(row.geoIP) : undefined,
       asn: row.asn || undefined, chains: row.chains ? row.chains.split(',') : [],
     })) as IPStats[];
   }
@@ -154,7 +154,7 @@ export class IPRepository extends BaseRepository {
 
     return rows.map(row => ({
       ...row, domains: row.domains ? row.domains.split(',') : [],
-      geoIP: row.geoIP ? JSON.parse(row.geoIP).filter(Boolean) : undefined,
+      geoIP: row.geoIP ? JSON.parse(row.geoIP) : undefined,
       asn: row.asn || undefined, chains: row.chains ? row.chains.split(',') : [],
     })) as IPStats[];
   }
@@ -232,7 +232,7 @@ export class IPRepository extends BaseRepository {
           ip: row.ip, domains: row.domains ? row.domains.split(',').filter(Boolean) : [],
           totalUpload: row.totalUpload, totalDownload: row.totalDownload,
           totalConnections: row.totalConnections, lastSeen: row.lastSeen,
-          geoIP: row.geoIP ? JSON.parse(row.geoIP).filter(Boolean) : undefined,
+          geoIP: row.geoIP ? JSON.parse(row.geoIP) : undefined,
           asn: row.asn || undefined,
           chains: this.expandShortChainsForRules(backendId, chains, rules),
         };
@@ -272,7 +272,7 @@ export class IPRepository extends BaseRepository {
         ip: row.ip, domains: row.domains ? row.domains.split(',') : [],
         totalUpload: row.totalUpload, totalDownload: row.totalDownload,
         totalConnections: row.totalConnections, lastSeen: row.lastSeen,
-        geoIP: row.geoIP ? JSON.parse(row.geoIP).filter(Boolean) : undefined,
+        geoIP: row.geoIP ? JSON.parse(row.geoIP) : undefined,
         asn: row.asn || undefined,
         chains: this.expandShortChainsForRules(backendId, chains, rules),
       };
@@ -330,7 +330,7 @@ export class IPRepository extends BaseRepository {
         const chains = row.chains ? row.chains.split(',').filter(Boolean) : [];
         return {
           ...row, domains: row.domains ? row.domains.split(',').filter(Boolean) : [],
-          geoIP: row.geoIP ? JSON.parse(row.geoIP).filter(Boolean) : undefined,
+          geoIP: row.geoIP ? JSON.parse(row.geoIP) : undefined,
           asn: row.asn || undefined,
           chains: this.expandShortChainsForRules(backendId, chains, rules),
         };

--- a/apps/collector/src/database/repositories/proxy.repository.ts
+++ b/apps/collector/src/database/repositories/proxy.repository.ts
@@ -87,7 +87,7 @@ export class ProxyRepository extends BaseRepository {
       }>;
       return rows.map(row => ({
         ...row, domains: row.domains ? row.domains.split(',').filter(Boolean) : [], chains: [chain],
-        asn: row.asn || undefined, geoIP: row.geoIP ? JSON.parse(row.geoIP).filter(Boolean) : undefined,
+        asn: row.asn || undefined, geoIP: row.geoIP ? JSON.parse(row.geoIP) : undefined,
       })) as IPStats[];
     }
 

--- a/apps/collector/src/database/repositories/rule.repository.ts
+++ b/apps/collector/src/database/repositories/rule.repository.ts
@@ -248,7 +248,7 @@ export class RuleRepository extends BaseRepository {
       const chains = row.chains ? row.chains.split(',').filter(Boolean) : [];
       return {
         ...row, domains: row.domains ? row.domains.split(',').filter(Boolean) : [],
-        geoIP: row.geoIP ? JSON.parse(row.geoIP).filter(Boolean) : undefined,
+        geoIP: row.geoIP ? JSON.parse(row.geoIP) : undefined,
         asn: row.asn || undefined,
         chains: this.expandShortChainsForRules(backendId, chains, [rule]),
       };


### PR DESCRIPTION
When resolving geoIP information from the database, JSON arrays like `["US", "United States", "", "Google LLC"]` were being improperly filtered with `.filter(Boolean)`. This stripped out empty strings, causing the array to shrink (e.g. `["US", "United States", "Google LLC"]`) which led to index mismatching on the frontend. The city field would improperly display the AS organization, while the AS organization field became empty.

Removed `.filter(Boolean)` on `JSON.parse(row.geoIP)` across all repositories to preserve the exact structure of the array.

before：
<img width="1298" height="341" alt="image" src="https://github.com/user-attachments/assets/e6c6f555-0486-43b4-9b17-257ceccdcf0e" />

after:
<img width="1271" height="288" alt="image" src="https://github.com/user-attachments/assets/108b73aa-48b9-4ec6-9f00-71e567b23f5b" />
