### PR TITLE
fix(collector): correct daily trend bucketing (#82)

### DIFF
--- a/apps/collector/src/modules/realtime/realtime.merger.ts
+++ b/apps/collector/src/modules/realtime/realtime.merger.ts
@@ -24,9 +24,10 @@ function toMinuteKey(tsMs: number): string {
 
 function bucketMinuteKey(minuteKey: string, bucketMinutes: number): string {
   if (bucketMinutes <= 1) return minuteKey;
-  const minute = parseInt(minuteKey.slice(14, 16), 10);
-  const bucketMinute = Math.floor(minute / bucketMinutes) * bucketMinutes;
-  return `${minuteKey.slice(0, 14)}${String(bucketMinute).padStart(2, '0')}:00`;
+  const timestampMs = Date.parse(`${minuteKey}Z`);
+  if (!Number.isFinite(timestampMs)) return minuteKey;
+  const bucketMs = Math.floor(bucketMinutes) * 60 * 1000;
+  return toMinuteKey(Math.floor(timestampMs / bucketMs) * bucketMs);
 }
 
 function normalizeSortOrder(order?: string): 'asc' | 'desc' {

--- a/apps/collector/src/modules/realtime/realtime.store.ts
+++ b/apps/collector/src/modules/realtime/realtime.store.ts
@@ -119,9 +119,10 @@ function toMinuteKey(tsMs: number): string {
 
 function bucketMinuteKey(minuteKey: string, bucketMinutes: number): string {
   if (bucketMinutes <= 1) return minuteKey;
-  const minute = parseInt(minuteKey.slice(14, 16), 10);
-  const bucketMinute = Math.floor(minute / bucketMinutes) * bucketMinutes;
-  return `${minuteKey.slice(0, 14)}${String(bucketMinute).padStart(2, '0')}:00`;
+  const timestampMs = Date.parse(`${minuteKey}Z`);
+  if (!Number.isFinite(timestampMs)) return minuteKey;
+  const bucketMs = Math.floor(bucketMinutes) * 60 * 1000;
+  return toMinuteKey(Math.floor(timestampMs / bucketMs) * bucketMs);
 }
 
 function normalizeSortOrder(order?: string): 'asc' | 'desc' {

--- a/apps/collector/src/modules/realtime/realtime.trend.test.ts
+++ b/apps/collector/src/modules/realtime/realtime.trend.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { RealtimeMerger } from './realtime.merger.js';
+import { RealtimeStore } from './realtime.store.js';
+
+const backendId = 1;
+const nowMs = Date.parse('2026-07-23T15:00:00Z');
+
+function createStore(): RealtimeStore {
+  const store = new RealtimeStore();
+  store.minuteByBackend.set(backendId, new Map([
+    ['2026-07-23T03:37:00', { upload: 1, download: 2, lastUpdated: nowMs }],
+    ['2026-07-23T14:37:00', { upload: 3, download: 4, lastUpdated: nowMs }],
+  ]));
+  return store;
+}
+
+describe('realtime trend bucketing', () => {
+  it('groups RealtimeStore traffic from the same UTC day into one daily bucket', () => {
+    const store = createStore();
+
+    expect(store.mergeTrend(backendId, [], 24 * 60, 24 * 60, nowMs)).toEqual([
+      { time: '2026-07-23T00:00:00', upload: 4, download: 6 },
+    ]);
+  });
+
+  it('groups RealtimeMerger traffic from the same UTC day into one daily bucket', () => {
+    const store = createStore();
+    const merger = new RealtimeMerger(store);
+
+    expect(merger.mergeTrend(backendId, [], 24 * 60, 24 * 60, nowMs)).toEqual([
+      { time: '2026-07-23T00:00:00', upload: 4, download: 6 },
+    ]);
+  });
+});

--- a/apps/collector/src/modules/stats/stats.controller.test.ts
+++ b/apps/collector/src/modules/stats/stats.controller.test.ts
@@ -1,0 +1,66 @@
+import type { FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createTestBackend, createTestDatabase } from '../../__tests__/helpers.js';
+import { createApp } from '../app/app.js';
+import type { StatsDatabase } from '../db/db.js';
+import { realtimeStore } from '../realtime/realtime.store.js';
+
+describe('StatsController', () => {
+  let app: FastifyInstance;
+  let backendId: number;
+  let cleanup: () => void;
+  let db: StatsDatabase;
+
+  beforeEach(async () => {
+    ({ db, cleanup } = createTestDatabase());
+    backendId = createTestBackend(db);
+    app = await createApp({
+      port: 0,
+      db,
+      realtimeStore,
+      logger: false,
+      autoListen: false,
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
+    realtimeStore.clearBackend(backendId);
+    cleanup();
+  });
+
+  it('accepts a daily bucket for aggregated traffic trends', async () => {
+    const baseUpdate = {
+      domain: 'example.com',
+      ip: '203.0.113.1',
+      chain: 'DIRECT',
+      chains: ['DIRECT'],
+      rule: 'Match',
+      rulePayload: '',
+    };
+    db.batchUpdateTrafficStats(backendId, [
+      {
+        ...baseUpdate,
+        upload: 1,
+        download: 2,
+        timestampMs: Date.parse('2026-07-23T03:37:00Z'),
+      },
+      {
+        ...baseUpdate,
+        upload: 3,
+        download: 4,
+        timestampMs: Date.parse('2026-07-23T14:37:00Z'),
+      },
+    ]);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: `/api/stats/trend/aggregated?backendId=${backendId}&start=2026-07-23T00%3A00%3A00Z&end=2026-07-23T23%3A59%3A59Z&minutes=1440&bucketMinutes=1440`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual([
+      { time: '2026-07-23T00:00:00', upload: 4, download: 6 },
+    ]);
+  });
+});

--- a/apps/collector/src/modules/stats/stats.controller.ts
+++ b/apps/collector/src/modules/stats/stats.controller.ts
@@ -757,7 +757,7 @@ const statsController: FastifyPluginAsync = async (fastify: FastifyInstance): Pr
     const query = request.query as Record<string, string | undefined>;
     const { minutes = '30', bucketMinutes = '1' } = query;
     const windowMinutes = service.parseLimit(minutes, 30, 60 * 24 * 7);
-    const bucket = service.parseLimit(bucketMinutes, 1, 60);
+    const bucket = service.parseLimit(bucketMinutes, 1, 24 * 60);
     return await service.getTrafficTrendAggregatedWithRouting(
       backendId,
       timeRange,


### PR DESCRIPTION
## Summary

- allow the aggregated trend HTTP endpoint to accept 1440-minute daily buckets
- align realtime buckets on UTC epoch boundaries instead of only flooring the minute field
- cover both realtime implementations and the real HTTP → SQLite daily aggregation path

## Root cause

The HTTP controller clamped `bucketMinutes` to 60 even though the web client requests 1440 for multi-day charts. Realtime bucketing also retained the source hour, so two points from the same UTC day became separate hourly points.

This supersedes #83, which changes tooltip formatting but does not correct either data-path bug.

## Validation

- targeted regression tests: 2 files, 3 tests passed
- collector TypeScript: passed
- collector lint: 0 errors (158 existing warnings)
- collector full suite: 13 files, 67 tests passed
- `git diff --check`: passed

Fixes #82