### PR TITLE
fix(surge): use sourceAddress as device source IP instead of localAddress

### DIFF
--- a/apps/agent/internal/gateway/client.go
+++ b/apps/agent/internal/gateway/client.go
@@ -275,7 +275,7 @@ func (c *Client) collectSurge(ctx context.Context) ([]domain.FlowSnapshot, error
 			ip = extractHost(remoteAddress)
 		}
 
-		sourceIP := extractHost(defaultString(strings.TrimSpace(reqItem.LocalAddress), strings.TrimSpace(reqItem.SourceAddress)))
+		sourceIP := extractHost(defaultString(strings.TrimSpace(reqItem.SourceAddress), strings.TrimSpace(reqItem.LocalAddress)))
 		chains := convertSurgeChains(reqItem.PolicyName, reqItem.OriginalPolicyName, []string(reqItem.Notes))
 		rule := defaultString(strings.TrimSpace(lastChain(chains)), defaultString(strings.TrimSpace(reqItem.OriginalPolicyName), "Match"))
 		rulePayload := strings.TrimSpace(reqItem.Rule)

--- a/apps/collector/src/modules/collector/surge.collector.ts
+++ b/apps/collector/src/modules/collector/surge.collector.ts
@@ -492,7 +492,7 @@ export function createSurgeCollector(
           : isIP(remoteAddress)
             ? remoteAddress
             : "";
-        const sourceIP = req.localAddress || "";
+        const sourceIP = req.sourceAddress || req.localAddress || "";
 
         // For Surge:
         // - policyName = final proxy (e.g., "🇺🇸 US-SJC-IEPL")


### PR DESCRIPTION
## Problem

When Surge runs as a gateway (TUN/DHCP mode), the dashboard shows **only the gateway machine itself** (e.g. `10.0.0.88`) in the Devices view, even though many LAN clients are behind it.

Root cause: Surge's `/v1/requests/recent` API reports:
- `sourceAddress` = the **client device IP** that initiated the connection (e.g. `10.0.0.44`, `10.0.0.173`)
- `localAddress` = the **gateway's own IP** (the machine Surge runs on)

Both the TypeScript collector and the Go agent picked `localAddress` as the device source IP (falling back to `sourceAddress`), so all LAN client traffic was attributed to the gateway itself.

## Fix

Swap the priority so `sourceAddress` (real client device) is used as the device identifier, keeping `localAddress` as a fallback when `sourceAddress` is absent.

- `apps/collector/src/modules/collector/surge.collector.ts`: `req.localAddress || ""` → `req.sourceAddress || req.localAddress || ""`
- `apps/agent/internal/gateway/client.go`: swapped `defaultString(LocalAddress, SourceAddress)` → `defaultString(SourceAddress, LocalAddress)`

## Verification

- Surge API sample (gateway at 10.0.0.88) before fix — all devices collapsed to the gateway:
  ```
  device_stats: only source_ip=10.0.0.88 (gateway)
  ```
- After fix, device stats will be attributed to real clients (10.0.0.44, 10.0.0.173, ...).
- TypeScript typecheck passes; Go build passes.