### PR TITLE
fix(auth): accept URL-encoded session tokens

### DIFF
--- a/apps/collector/src/modules/auth/auth.service.test.ts
+++ b/apps/collector/src/modules/auth/auth.service.test.ts
@@ -36,6 +36,17 @@ describe('AuthService', () => {
       expect(result.valid).toBe(true);
     });
 
+    it('should verify URL-encoded session tokens', async () => {
+      const token = 'abc1+/=';
+      await authService.enableAuth(token);
+
+      const encodedToken = encodeURIComponent(token);
+      expect(encodedToken).toBe('abc1%2B%2F%3D');
+
+      const result = await authService.verifyToken(encodedToken);
+      expect(result.valid).toBe(true);
+    });
+
     it('should reject incorrect token', async () => {
       await authService.enableAuth('correct1');
 

--- a/apps/collector/src/modules/auth/auth.service.ts
+++ b/apps/collector/src/modules/auth/auth.service.ts
@@ -87,6 +87,21 @@ export class AuthService {
       return { valid: true };
     }
 
+    // WebSocket authentication reads the raw Cookie header, where values set by
+    // @fastify/cookie may still be percent-encoded. Keep the original check
+    // above for backwards compatibility, then retry with the decoded value.
+    try {
+      const decodedToken = decodeURIComponent(token);
+      if (decodedToken !== token) {
+        const decodedTokenHash = await hashToken(decodedToken);
+        if (await timingSafeHashEqual(decodedTokenHash, config.tokenHash)) {
+          return { valid: true };
+        }
+      }
+    } catch {
+      // Malformed percent-encoding is simply treated as an invalid token.
+    }
+
     return { valid: false, message: 'Invalid token' };
   }
 


### PR DESCRIPTION
## Summary

Fix WebSocket authentication when the `neko-session` cookie contains percent-encoded characters such as `%2B`, `%2F`, or `%3D`.

The browser receives the session cookie through `@fastify/cookie`, which percent-encodes special characters. The WebSocket server reads the raw `Cookie` header and passes the encoded value to `AuthService.verifyToken()`, causing the SHA-256 hash comparison to fail and the socket to close with code `4003` (`Invalid token`).

## Fix

- Preserve the existing raw-token verification path.
- If verification fails and the token is percent-encoded, retry using `decodeURIComponent(token)`.
- Treat malformed percent-encoding as an invalid token without throwing.
- Add a regression test covering a token containing `+`, `/`, and `=`.

## Reproduction

1. Enable access control with a token containing special characters, e.g. `abc1+/=`.
2. Log in through the web UI.
3. The HTTP API works, but the WebSocket repeatedly connects and closes with:
   - `4003 Invalid token`
4. The `Cookie` header contains an encoded value such as `abc1%2B%2F%3D`.

## Result

Encoded session-cookie values authenticate successfully while existing unencoded tokens keep the same behavior.